### PR TITLE
feat: Add `jsconfig.json` in javascript templates

### DIFF
--- a/template-alpine-js/jsconfig.json
+++ b/template-alpine-js/jsconfig.json
@@ -1,0 +1,1 @@
+{ "typeAcquisition": { "include": ["chrome"] } }

--- a/template-inferno-js/jsconfig.json
+++ b/template-inferno-js/jsconfig.json
@@ -1,0 +1,1 @@
+{ "typeAcquisition": { "include": ["chrome"] } }

--- a/template-lit-js/jsconfig.json
+++ b/template-lit-js/jsconfig.json
@@ -1,0 +1,1 @@
+{ "typeAcquisition": { "include": ["chrome"] } }

--- a/template-preact-js/jsconfig.json
+++ b/template-preact-js/jsconfig.json
@@ -1,0 +1,1 @@
+{ "typeAcquisition": { "include": ["chrome"] } }

--- a/template-react-js/jsconfig.json
+++ b/template-react-js/jsconfig.json
@@ -1,0 +1,1 @@
+{ "typeAcquisition": { "include": ["chrome"] } }

--- a/template-solid-js/jsconfig.json
+++ b/template-solid-js/jsconfig.json
@@ -1,0 +1,1 @@
+{ "typeAcquisition": { "include": ["chrome"] } }

--- a/template-stencil-js/jsconfig.json
+++ b/template-stencil-js/jsconfig.json
@@ -1,0 +1,1 @@
+{ "typeAcquisition": { "include": ["chrome"] } }

--- a/template-svelte-js/jsconfig.json
+++ b/template-svelte-js/jsconfig.json
@@ -1,0 +1,1 @@
+{ "typeAcquisition": { "include": ["chrome"] } }

--- a/template-vanilla-js/jsconfig.json
+++ b/template-vanilla-js/jsconfig.json
@@ -1,0 +1,1 @@
+{ "typeAcquisition": { "include": ["chrome"] } }

--- a/template-vue-js/jsconfig.json
+++ b/template-vue-js/jsconfig.json
@@ -1,0 +1,1 @@
+{"typeAcquisition": {"include": ["chrome"]}}


### PR DESCRIPTION
As per #36 added `jsconfig.json` in all of the javascript templates. This will help the developer to autocomplete the Chrome APIs.