### PR TITLE
fix: tsconfig in `template-solid-ts`

### DIFF
--- a/template-solid-ts/tsconfig.json
+++ b/template-solid-ts/tsconfig.json
@@ -14,7 +14,8 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,
-    "jsx": "react-jsx"
+    "jsx": "preserve",
+    "jsxImportSource": "solid-js"
   },
   "include": ["src"],
   "references": [{ "path": "./tsconfig.node.json" }]


### PR DESCRIPTION
Hi, thanks for the great tool!

Form [Solidjs docs](https://www.solidjs.com/guides/typescript#configuring-typescript) `tsconfig.jsx` should use 

```json
"jsx": "preserve",
"jsxImportSource": "solid-js"
```

otherwise, it will create a lot of TS errors.