### PR TITLE
migrating from gulp 4 to 5

### DIFF
--- a/template-alpine-js/package.json
+++ b/template-alpine-js/package.json
@@ -27,7 +27,7 @@
   },
   "devDependencies": {
     "@crxjs/vite-plugin": "^2.0.0-beta.19",
-    "gulp": "^4.0.2",
+    "gulp": "^5.0.0",
     "gulp-zip": "^6.0.0",
     "vite": "^4.4.11"
   }

--- a/template-alpine-js/src/zip.js
+++ b/template-alpine-js/src/zip.js
@@ -5,6 +5,6 @@ const require = createRequire(import.meta.url)
 const manifest = require('../build/manifest.json')
 
 gulp
-  .src('build/**')
+  .src('build/**', { encoding: false })
   .pipe(zip(`${manifest.name.replaceAll(' ', '-')}-${manifest.version}.zip`))
   .pipe(gulp.dest('package'))

--- a/template-alpine-ts/package.json
+++ b/template-alpine-ts/package.json
@@ -29,7 +29,7 @@
     "@crxjs/vite-plugin": "^2.0.0-beta.19",
     "@types/alpinejs": "^3.13.2",
     "@types/chrome": "^0.0.246",
-    "gulp": "^4.0.2",
+    "gulp": "^5.0.0",
     "gulp-zip": "^6.0.0",
     "typescript": "^5.2.2",
     "vite": "^4.4.11"

--- a/template-alpine-ts/src/zip.js
+++ b/template-alpine-ts/src/zip.js
@@ -5,6 +5,6 @@ const require = createRequire(import.meta.url)
 const manifest = require('../build/manifest.json')
 
 gulp
-  .src('build/**')
+  .src('build/**', { encoding: false })
   .pipe(zip(`${manifest.name.replaceAll(' ', '-')}-${manifest.version}.zip`))
   .pipe(gulp.dest('package'))

--- a/template-inferno-js/package.json
+++ b/template-inferno-js/package.json
@@ -29,7 +29,7 @@
     "@babel/core": "7.23.2",
     "@babel/parser": "7.23.0",
     "@crxjs/vite-plugin": "^2.0.0-beta.19",
-    "gulp": "^4.0.2",
+    "gulp": "^5.0.0",
     "gulp-zip": "^6.0.0",
     "vite": "^4.4.11",
     "vite-plugin-inferno": "0.0.1"

--- a/template-inferno-js/src/zip.js
+++ b/template-inferno-js/src/zip.js
@@ -5,6 +5,6 @@ const require = createRequire(import.meta.url)
 const manifest = require('../build/manifest.json')
 
 gulp
-  .src('build/**')
+  .src('build/**', { encoding: false })
   .pipe(zip(`${manifest.name.replaceAll(' ', '-')}-${manifest.version}.zip`))
   .pipe(gulp.dest('package'))

--- a/template-inferno-ts/package.json
+++ b/template-inferno-ts/package.json
@@ -30,7 +30,7 @@
     "@babel/parser": "7.23.0",
     "@crxjs/vite-plugin": "^2.0.0-beta.19",
     "@types/chrome": "^0.0.246",
-    "gulp": "^4.0.2",
+    "gulp": "^5.0.0",
     "gulp-zip": "^6.0.0",
     "typescript": "^5.2.2",
     "vite": "^4.4.11",

--- a/template-inferno-ts/src/zip.js
+++ b/template-inferno-ts/src/zip.js
@@ -5,6 +5,6 @@ const require = createRequire(import.meta.url)
 const manifest = require('../build/manifest.json')
 
 gulp
-  .src('build/**')
+  .src('build/**', { encoding: false })
   .pipe(zip(`${manifest.name.replaceAll(' ', '-')}-${manifest.version}.zip`))
   .pipe(gulp.dest('package'))

--- a/template-lit-js/package.json
+++ b/template-lit-js/package.json
@@ -27,7 +27,7 @@
   },
   "devDependencies": {
     "@crxjs/vite-plugin": "^2.0.0-beta.19",
-    "gulp": "^4.0.2",
+    "gulp": "^5.0.0",
     "gulp-zip": "^6.0.0",
     "prettier": "^3.0.3",
     "vite": "^3.2.7"

--- a/template-lit-js/src/zip.js
+++ b/template-lit-js/src/zip.js
@@ -5,6 +5,6 @@ const require = createRequire(import.meta.url)
 const manifest = require('../build/manifest.json')
 
 gulp
-  .src('build/**')
+  .src('build/**', { encoding: false })
   .pipe(zip(`${manifest.name.replaceAll(' ', '-')}-${manifest.version}.zip`))
   .pipe(gulp.dest('package'))

--- a/template-lit-ts/package.json
+++ b/template-lit-ts/package.json
@@ -28,7 +28,7 @@
   "devDependencies": {
     "@crxjs/vite-plugin": "^2.0.0-beta.19",
     "@types/chrome": "^0.0.246",
-    "gulp": "^4.0.2",
+    "gulp": "^5.0.0",
     "gulp-zip": "^6.0.0",
     "path": "^0.12.7",
     "prettier": "^3.0.3",

--- a/template-lit-ts/src/zip.js
+++ b/template-lit-ts/src/zip.js
@@ -5,6 +5,6 @@ const require = createRequire(import.meta.url)
 const manifest = require('../build/manifest.json')
 
 gulp
-  .src('build/**')
+  .src('build/**', { encoding: false })
   .pipe(zip(`${manifest.name.replaceAll(' ', '-')}-${manifest.version}.zip`))
   .pipe(gulp.dest('package'))

--- a/template-preact-js/package.json
+++ b/template-preact-js/package.json
@@ -28,7 +28,7 @@
   "devDependencies": {
     "@crxjs/vite-plugin": "^2.0.0-beta.19",
     "@preact/preset-vite": "^2.6.0",
-    "gulp": "^4.0.2",
+    "gulp": "^5.0.0",
     "gulp-zip": "^6.0.0",
     "prettier": "^3.0.3",
     "vite": "^4.4.11"

--- a/template-preact-js/src/zip.js
+++ b/template-preact-js/src/zip.js
@@ -5,6 +5,6 @@ const require = createRequire(import.meta.url)
 const manifest = require('../build/manifest.json')
 
 gulp
-  .src('build/**')
+  .src('build/**', { encoding: false })
   .pipe(zip(`${manifest.name.replaceAll(' ', '-')}-${manifest.version}.zip`))
   .pipe(gulp.dest('package'))

--- a/template-preact-ts/package.json
+++ b/template-preact-ts/package.json
@@ -29,7 +29,7 @@
     "@crxjs/vite-plugin": "^2.0.0-beta.19",
     "@preact/preset-vite": "^2.6.0",
     "@types/chrome": "^0.0.246",
-    "gulp": "^4.0.2",
+    "gulp": "^5.0.0",
     "gulp-zip": "^6.0.0",
     "prettier": "^3.0.3",
     "typescript": "^5.2.2",

--- a/template-preact-ts/src/zip.js
+++ b/template-preact-ts/src/zip.js
@@ -5,6 +5,6 @@ const require = createRequire(import.meta.url)
 const manifest = require('../build/manifest.json')
 
 gulp
-  .src('build/**')
+  .src('build/**', { encoding: false })
   .pipe(zip(`${manifest.name.replaceAll(' ', '-')}-${manifest.version}.zip`))
   .pipe(gulp.dest('package'))

--- a/template-react-js/package.json
+++ b/template-react-js/package.json
@@ -32,7 +32,7 @@
     "@types/react-dom": "^18.2.13",
     "@vitejs/plugin-react": "^4.1.0",
     "glob": "^10.3.10",
-    "gulp": "^4.0.2",
+    "gulp": "^5.0.0",
     "gulp-zip": "^6.0.0",
     "prettier": "^3.0.3",
     "vite": "^4.4.11"

--- a/template-react-js/src/zip.js
+++ b/template-react-js/src/zip.js
@@ -5,6 +5,6 @@ const require = createRequire(import.meta.url)
 const manifest = require('../build/manifest.json')
 
 gulp
-  .src('build/**')
+  .src('build/**', { encoding: false })
   .pipe(zip(`${manifest.name.replaceAll(' ', '-')}-${manifest.version}.zip`))
   .pipe(gulp.dest('package'))

--- a/template-react-ts/package.json
+++ b/template-react-ts/package.json
@@ -32,7 +32,7 @@
     "@types/react": "^18.2.28",
     "@types/react-dom": "^18.2.13",
     "@vitejs/plugin-react": "^4.1.0",
-    "gulp": "^4.0.2",
+    "gulp": "^5.0.0",
     "gulp-zip": "^6.0.0",
     "prettier": "^3.0.3",
     "typescript": "^5.2.2",

--- a/template-react-ts/src/zip.js
+++ b/template-react-ts/src/zip.js
@@ -5,6 +5,6 @@ const require = createRequire(import.meta.url)
 const manifest = require('../build/manifest.json')
 
 gulp
-  .src('build/**')
+  .src('build/**', { encoding: false })
   .pipe(zip(`${manifest.name.replaceAll(' ', '-')}-${manifest.version}.zip`))
   .pipe(gulp.dest('package'))

--- a/template-solid-js/package.json
+++ b/template-solid-js/package.json
@@ -25,7 +25,7 @@
   },
   "devDependencies": {
     "@crxjs/vite-plugin": "^2.0.0-beta.19",
-    "gulp": "^4.0.2",
+    "gulp": "^5.0.0",
     "gulp-zip": "^6.0.0",
     "prettier": "^3.0.3",
     "vite": "^4.4.11",

--- a/template-solid-js/src/zip.js
+++ b/template-solid-js/src/zip.js
@@ -5,6 +5,6 @@ const require = createRequire(import.meta.url)
 const manifest = require('../build/manifest.json')
 
 gulp
-  .src('build/**')
+  .src('build/**', { encoding: false })
   .pipe(zip(`${manifest.name.replaceAll(' ', '-')}-${manifest.version}.zip`))
   .pipe(gulp.dest('package'))

--- a/template-solid-ts/package.json
+++ b/template-solid-ts/package.json
@@ -26,7 +26,7 @@
   "devDependencies": {
     "@crxjs/vite-plugin": "^2.0.0-beta.19",
     "@types/chrome": "^0.0.246",
-    "gulp": "^4.0.2",
+    "gulp": "^5.0.0",
     "gulp-zip": "^6.0.0",
     "prettier": "^3.0.3",
     "typescript": "^5.2.2",

--- a/template-solid-ts/src/zip.js
+++ b/template-solid-ts/src/zip.js
@@ -5,6 +5,6 @@ const require = createRequire(import.meta.url)
 const manifest = require('../build/manifest.json')
 
 gulp
-  .src('build/**')
+  .src('build/**', { encoding: false })
   .pipe(zip(`${manifest.name.replaceAll(' ', '-')}-${manifest.version}.zip`))
   .pipe(gulp.dest('package'))

--- a/template-stencil-ts/package.json
+++ b/template-stencil-ts/package.json
@@ -26,7 +26,7 @@
     "@types/chrome": "^0.0.246",
     "@types/node": "^20.8.3",
     "express": "^4.18.2",
-    "gulp": "^4.0.2",
+    "gulp": "^5.0.0",
     "gulp-zip": "^6.0.0",
     "prettier": "^3.0.3",
     "typescript": "^5.2.2"

--- a/template-stencil-ts/src/zip.js
+++ b/template-stencil-ts/src/zip.js
@@ -5,6 +5,6 @@ const require = createRequire(import.meta.url)
 const manifest = require('../build/manifest.json')
 
 gulp
-  .src('build/**')
+  .src('build/**', { encoding: false })
   .pipe(zip(`${manifest.name.replaceAll(' ', '-')}-${manifest.version}.zip`))
   .pipe(gulp.dest('package'))

--- a/template-svelte-js/package.json
+++ b/template-svelte-js/package.json
@@ -25,7 +25,7 @@
   "devDependencies": {
     "@crxjs/vite-plugin": "^2.0.0-beta.19",
     "@sveltejs/vite-plugin-svelte": "2.4.6",
-    "gulp": "^4.0.2",
+    "gulp": "^5.0.0",
     "gulp-zip": "^6.0.0",
     "prettier": "^3.0.3",
     "prettier-plugin-svelte": "^3.0.3",

--- a/template-svelte-js/src/zip.js
+++ b/template-svelte-js/src/zip.js
@@ -5,6 +5,6 @@ const require = createRequire(import.meta.url)
 const manifest = require('../build/manifest.json')
 
 gulp
-  .src('build/**')
+  .src('build/**', { encoding: false })
   .pipe(zip(`${manifest.name.replaceAll(' ', '-')}-${manifest.version}.zip`))
   .pipe(gulp.dest('package'))

--- a/template-svelte-ts/package.json
+++ b/template-svelte-ts/package.json
@@ -26,7 +26,7 @@
     "@crxjs/vite-plugin": "^2.0.0-beta.19",
     "@sveltejs/vite-plugin-svelte": "2.4.6",
     "@types/chrome": "^0.0.246",
-    "gulp": "^4.0.2",
+    "gulp": "^5.0.0",
     "gulp-zip": "^6.0.0",
     "prettier": "^3.0.3",
     "prettier-plugin-svelte": "^3.0.3",

--- a/template-svelte-ts/src/zip.js
+++ b/template-svelte-ts/src/zip.js
@@ -5,6 +5,6 @@ const require = createRequire(import.meta.url)
 const manifest = require('../build/manifest.json')
 
 gulp
-  .src('build/**')
+  .src('build/**', { encoding: false })
   .pipe(zip(`${manifest.name.replaceAll(' ', '-')}-${manifest.version}.zip`))
   .pipe(gulp.dest('package'))

--- a/template-vanilla-js/package.json
+++ b/template-vanilla-js/package.json
@@ -24,7 +24,7 @@
   },
   "devDependencies": {
     "@crxjs/vite-plugin": "^2.0.0-beta.19",
-    "gulp": "^4.0.2",
+    "gulp": "^5.0.0",
     "gulp-zip": "^6.0.0",
     "prettier": "^3.0.3",
     "vite": "^4.4.11"

--- a/template-vanilla-js/src/zip.js
+++ b/template-vanilla-js/src/zip.js
@@ -5,6 +5,6 @@ const require = createRequire(import.meta.url)
 const manifest = require('../build/manifest.json')
 
 gulp
-  .src('build/**')
+  .src('build/**', { encoding: false })
   .pipe(zip(`${manifest.name.replaceAll(' ', '-')}-${manifest.version}.zip`))
   .pipe(gulp.dest('package'))

--- a/template-vanilla-ts/package.json
+++ b/template-vanilla-ts/package.json
@@ -25,7 +25,7 @@
   "devDependencies": {
     "@crxjs/vite-plugin": "^2.0.0-beta.19",
     "@types/chrome": "^0.0.246",
-    "gulp": "^4.0.2",
+    "gulp": "^5.0.0",
     "gulp-zip": "^6.0.0",
     "prettier": "^3.0.3",
     "typescript": "^5.2.2",

--- a/template-vanilla-ts/src/zip.js
+++ b/template-vanilla-ts/src/zip.js
@@ -5,6 +5,6 @@ const require = createRequire(import.meta.url)
 const manifest = require('../build/manifest.json')
 
 gulp
-  .src('build/**')
+  .src('build/**', { encoding: false })
   .pipe(zip(`${manifest.name.replaceAll(' ', '-')}-${manifest.version}.zip`))
   .pipe(gulp.dest('package'))

--- a/template-vue-js/package.json
+++ b/template-vue-js/package.json
@@ -28,7 +28,7 @@
   "devDependencies": {
     "@crxjs/vite-plugin": "^2.0.0-beta.19",
     "@vitejs/plugin-vue": "^4.4.0",
-    "gulp": "^4.0.2",
+    "gulp": "^5.0.0",
     "gulp-zip": "^6.0.0",
     "prettier": "^3.0.3",
     "vite": "^4.4.11"

--- a/template-vue-js/src/zip.js
+++ b/template-vue-js/src/zip.js
@@ -5,6 +5,6 @@ const require = createRequire(import.meta.url)
 const manifest = require('../build/manifest.json')
 
 gulp
-  .src('build/**')
+  .src('build/**', { encoding: false })
   .pipe(zip(`${manifest.name.replaceAll(' ', '-')}-${manifest.version}.zip`))
   .pipe(gulp.dest('package'))

--- a/template-vue-ts/package.json
+++ b/template-vue-ts/package.json
@@ -29,7 +29,7 @@
     "@crxjs/vite-plugin": "^2.0.0-beta.19",
     "@types/chrome": "^0.0.246",
     "@vitejs/plugin-vue": "^4.4.0",
-    "gulp": "^4.0.2",
+    "gulp": "^5.0.0",
     "gulp-zip": "^6.0.0",
     "prettier": "^3.0.3",
     "typescript": "^5.2.2",

--- a/template-vue-ts/src/zip.js
+++ b/template-vue-ts/src/zip.js
@@ -5,6 +5,6 @@ const require = createRequire(import.meta.url)
 const manifest = require('../build/manifest.json')
 
 gulp
-  .src('build/**')
+  .src('build/**', { encoding: false })
   .pipe(zip(`${manifest.name.replaceAll(' ', '-')}-${manifest.version}.zip`))
   .pipe(gulp.dest('package'))


### PR DESCRIPTION
Hello.

Regarding the title, we have migrated to gulp 5, which was released in May of this year, because gulp 4 has vulnerabilities in many dependent libraries that cannot be resolved.
As a note about migrating to gulp 5, the default encoding of the stream is UTF-8 (this is described in BREAKING CHANGES of gulp 5.0.0). In this repository, this caused icon images to break, so we fixed it by adding { encoding: false } to gulp.src so that it is not encoded.

<details>
<summary>Logs and vulnerability reports when creating a vanilla-ts template project and running npm install</summary>

```
>npm create chrome-ext

> npx
> create-chrome-ext

√ Project name: ... .
√ Author: ... no one
√ Framework: » vanilla
√ Language: » vanilla-ts

Scaffolding project in H:\workspace_browser_ext\test-project...

Done. Now run:

  npm install
  npm run dev

   Suggest you next step:
    1. cd
    2. Run npm install
    3. Open chrome://extensions/ in your browser
    4. Check the box for Developer mode in the top right.
    5. Click the Load unpacked extension button.
    6. Select the build/ directory that was created.

------------------------------
>npm install
npm warn deprecated inflight@1.0.6: This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and 
powerful.
npm warn deprecated source-map-url@0.4.1: See https://github.com/lydell/source-map-url#deprecated
npm warn deprecated urix@0.1.0: Please see https://github.com/lydell/urix#deprecated
npm warn deprecated glob@7.2.3: Glob versions prior to v9 are no longer supported
npm warn deprecated q@1.5.1: You or someone you depend on is using Q, the JavaScript Promise library that gave JavaScript developers strong feelings about promises. They can almost certainly migrate to the native JavaScript promise now. Thank you literally everyone for joining me in this bet against the odds. Be excellent to each other.
npm warn deprecated
npm warn deprecated (For a CapTP with native promises, see @endo/eventual-send and @endo/captp)
npm warn deprecated source-map-resolve@0.5.3: See https://github.com/lydell/source-map-resolve#deprecated
npm warn deprecated chokidar@2.1.8: Chokidar 2 does not receive security updates since 2019. Upgrade to chokidar 3 with 15x fewer dependencies
npm warn deprecated resolve-url@0.2.1: https://github.com/lydell/resolve-url#deprecated
npm warn deprecated sourcemap-codec@1.4.8: Please use @jridgewell/sourcemap-codec instead

added 457 packages, and audited 458 packages in 23s

44 packages are looking for funding
  run `npm fund` for details

11 vulnerabilities (7 moderate, 4 high)

To address all issues (including breaking changes), run:
  npm audit fix --force

Run `npm audit` for details.

------------------------------
>npm audit
# npm audit report

braces  <3.0.3
Severity: high
Uncontrolled resource consumption in braces - https://github.com/advisories/GHSA-grv7-fg5c-xmjg
fix available via `npm audit fix --force`
Will install gulp@5.0.0, which is a breaking change
node_modules/braces
  chokidar  1.3.0 - 2.1.8
  Depends on vulnerable versions of anymatch
  Depends on vulnerable versions of braces
  Depends on vulnerable versions of readdirp
  node_modules/chokidar
    glob-watcher  5.0.0 - 5.0.5
    Depends on vulnerable versions of anymatch
    Depends on vulnerable versions of chokidar
    node_modules/glob-watcher
      gulp  4.0.0 - 4.0.2
      Depends on vulnerable versions of glob-watcher
      Depends on vulnerable versions of gulp-cli
      node_modules/gulp
  micromatch  <=4.0.7
  Depends on vulnerable versions of braces
  node_modules/anymatch/node_modules/micromatch
  node_modules/findup-sync/node_modules/micromatch
  node_modules/matchdep/node_modules/micromatch
  node_modules/readdirp/node_modules/micromatch
    anymatch  1.2.0 - 2.0.0
    Depends on vulnerable versions of micromatch
    node_modules/anymatch
    findup-sync  0.4.0 - 3.0.0
    Depends on vulnerable versions of micromatch
    node_modules/findup-sync
    node_modules/matchdep/node_modules/findup-sync
      liftoff  2.2.3 - 3.1.0
      Depends on vulnerable versions of findup-sync
      node_modules/liftoff
        gulp-cli  1.3.0 - 2.3.0
        Depends on vulnerable versions of liftoff
        Depends on vulnerable versions of matchdep
        node_modules/gulp-cli
      matchdep  >=1.0.1
      Depends on vulnerable versions of findup-sync
      Depends on vulnerable versions of micromatch
      node_modules/matchdep
    readdirp  2.2.0 - 2.2.1
    Depends on vulnerable versions of micromatch
    node_modules/readdirp


11 vulnerabilities (7 moderate, 4 high)

To address all issues (including breaking changes), run:
  npm audit fix --force
```
</details>

Please note that we have not been able to test the code modified in this PR on all projects. After migrating to gulp5, we confirmed the following three points:
- vanilla-js
- vanilla-ts
- vue-ts (I got the following error in vue-tsc, but I don't think it's directly related to gulp5 migration. I didn't fix it because it's not related to this PR issue. Specifically, it can be solved by simply installing the latest vue-tsc.)

<details>
<summary>Error log when running npm run build on vue-ts template</summary>

```
>npm run build

> test-project@0.0.0 build
> vue-tsc --noEmit && vite build


H:\workspace_browser_ext\test-project\node_modules\vue-tsc\bin\vue-tsc.js:68
                        throw err;
                        ^
Search string not found: "for (const existingRoot of buildInfoVersionMap.roots) {"
(Use `node --trace-uncaught ...` to show where the exception was thrown)

Node.js v20.17.0
```
</details>

Please review the PR when you have time.