### PR TITLE
fix: update crxjs version to resolve CSP Issue #93

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-chrome-ext",
-  "version": "0.9.3",
+  "version": "0.9.4",
   "type": "module",
   "description": "Scaffolding your chrome extension, multiple boilerplates supported!",
   "author": "yalda",

--- a/template-alpine-js/package.json
+++ b/template-alpine-js/package.json
@@ -26,9 +26,9 @@
     "alpinejs": "^3.13.1"
   },
   "devDependencies": {
-    "@crxjs/vite-plugin": "^2.0.0-beta.19",
+    "@crxjs/vite-plugin": "^2.0.0-beta.26",
     "gulp": "^5.0.0",
     "gulp-zip": "^6.0.0",
-    "vite": "^4.4.11"
+    "vite": "^5.4.10"
   }
 }

--- a/template-alpine-ts/package.json
+++ b/template-alpine-ts/package.json
@@ -26,12 +26,12 @@
     "alpinejs": "^3.13.1"
   },
   "devDependencies": {
-    "@crxjs/vite-plugin": "^2.0.0-beta.19",
+    "@crxjs/vite-plugin": "^2.0.0-beta.26",
     "@types/alpinejs": "^3.13.2",
     "@types/chrome": "^0.0.246",
     "gulp": "^5.0.0",
     "gulp-zip": "^6.0.0",
     "typescript": "^5.2.2",
-    "vite": "^4.4.11"
+    "vite": "^5.4.10"
   }
 }

--- a/template-inferno-js/package.json
+++ b/template-inferno-js/package.json
@@ -28,10 +28,10 @@
   "devDependencies": {
     "@babel/core": "7.23.2",
     "@babel/parser": "7.23.0",
-    "@crxjs/vite-plugin": "^2.0.0-beta.19",
+    "@crxjs/vite-plugin": "^2.0.0-beta.26",
     "gulp": "^5.0.0",
     "gulp-zip": "^6.0.0",
-    "vite": "^4.4.11",
+    "vite": "^5.4.10",
     "vite-plugin-inferno": "0.0.1"
   }
 }

--- a/template-inferno-ts/package.json
+++ b/template-inferno-ts/package.json
@@ -28,12 +28,12 @@
   "devDependencies": {
     "@babel/core": "7.x",
     "@babel/parser": "7.23.0",
-    "@crxjs/vite-plugin": "^2.0.0-beta.19",
+    "@crxjs/vite-plugin": "^2.0.0-beta.26",
     "@types/chrome": "^0.0.246",
     "gulp": "^5.0.0",
     "gulp-zip": "^6.0.0",
     "typescript": "^5.2.2",
-    "vite": "^4.4.11",
+    "vite": "^5.4.10",
     "vite-plugin-inferno": "0.0.1"
   }
 }

--- a/template-lit-js/package.json
+++ b/template-lit-js/package.json
@@ -26,7 +26,7 @@
     "lit": "^2.8.0"
   },
   "devDependencies": {
-    "@crxjs/vite-plugin": "^2.0.0-beta.19",
+    "@crxjs/vite-plugin": "^2.0.0-beta.26",
     "gulp": "^5.0.0",
     "gulp-zip": "^6.0.0",
     "prettier": "^3.0.3",

--- a/template-lit-ts/package.json
+++ b/template-lit-ts/package.json
@@ -26,13 +26,13 @@
     "lit": "^3.0.0"
   },
   "devDependencies": {
-    "@crxjs/vite-plugin": "^2.0.0-beta.19",
+    "@crxjs/vite-plugin": "^2.0.0-beta.26",
     "@types/chrome": "^0.0.246",
     "gulp": "^5.0.0",
     "gulp-zip": "^6.0.0",
     "path": "^0.12.7",
     "prettier": "^3.0.3",
     "typescript": "^5.2.2",
-    "vite": "^4.4.11"
+    "vite": "^5.4.10"
   }
 }

--- a/template-preact-js/package.json
+++ b/template-preact-js/package.json
@@ -26,11 +26,11 @@
     "preact": "^10.18.1"
   },
   "devDependencies": {
-    "@crxjs/vite-plugin": "^2.0.0-beta.19",
+    "@crxjs/vite-plugin": "^2.0.0-beta.26",
     "@preact/preset-vite": "^2.6.0",
     "gulp": "^5.0.0",
     "gulp-zip": "^6.0.0",
     "prettier": "^3.0.3",
-    "vite": "^4.4.11"
+    "vite": "^5.4.10"
   }
 }

--- a/template-preact-ts/package.json
+++ b/template-preact-ts/package.json
@@ -26,13 +26,13 @@
     "preact": "^10.18.1"
   },
   "devDependencies": {
-    "@crxjs/vite-plugin": "^2.0.0-beta.19",
+    "@crxjs/vite-plugin": "^2.0.0-beta.26",
     "@preact/preset-vite": "^2.6.0",
     "@types/chrome": "^0.0.246",
     "gulp": "^5.0.0",
     "gulp-zip": "^6.0.0",
     "prettier": "^3.0.3",
     "typescript": "^5.2.2",
-    "vite": "^4.4.11"
+    "vite": "^5.4.10"
   }
 }

--- a/template-react-js/package.json
+++ b/template-react-js/package.json
@@ -27,7 +27,7 @@
     "react-dom": "^18.2.0"
   },
   "devDependencies": {
-    "@crxjs/vite-plugin": "^2.0.0-beta.19",
+    "@crxjs/vite-plugin": "^2.0.0-beta.26",
     "@types/react": "^18.2.28",
     "@types/react-dom": "^18.2.13",
     "@vitejs/plugin-react": "^4.1.0",
@@ -35,6 +35,6 @@
     "gulp": "^5.0.0",
     "gulp-zip": "^6.0.0",
     "prettier": "^3.0.3",
-    "vite": "^4.4.11"
+    "vite": "^5.4.10"
   }
 }

--- a/template-react-ts/package.json
+++ b/template-react-ts/package.json
@@ -27,7 +27,7 @@
     "react-dom": "^18.2.0"
   },
   "devDependencies": {
-    "@crxjs/vite-plugin": "^2.0.0-beta.19",
+    "@crxjs/vite-plugin": "^2.0.0-beta.26",
     "@types/chrome": "^0.0.246",
     "@types/react": "^18.2.28",
     "@types/react-dom": "^18.2.13",
@@ -36,6 +36,6 @@
     "gulp-zip": "^6.0.0",
     "prettier": "^3.0.3",
     "typescript": "^5.2.2",
-    "vite": "^4.4.11"
+    "vite": "^5.4.10"
   }
 }

--- a/template-react-ts/vite.config.ts
+++ b/template-react-ts/vite.config.ts
@@ -16,7 +16,6 @@ export default defineConfig(({ mode }) => {
         },
       },
     },
-
     plugins: [crx({ manifest }), react()],
   }
 })

--- a/template-solid-js/package.json
+++ b/template-solid-js/package.json
@@ -24,11 +24,11 @@
     "zip": "npm run build && node src/zip.js"
   },
   "devDependencies": {
-    "@crxjs/vite-plugin": "^2.0.0-beta.19",
+    "@crxjs/vite-plugin": "^2.0.0-beta.26",
     "gulp": "^5.0.0",
     "gulp-zip": "^6.0.0",
     "prettier": "^3.0.3",
-    "vite": "^4.4.11",
+    "vite": "^5.4.10",
     "vite-plugin-solid": "^2.7.1"
   },
   "dependencies": {

--- a/template-solid-ts/package.json
+++ b/template-solid-ts/package.json
@@ -24,13 +24,13 @@
     "zip": "npm run build && node src/zip.js"
   },
   "devDependencies": {
-    "@crxjs/vite-plugin": "^2.0.0-beta.19",
+    "@crxjs/vite-plugin": "^2.0.0-beta.26",
     "@types/chrome": "^0.0.246",
     "gulp": "^5.0.0",
     "gulp-zip": "^6.0.0",
     "prettier": "^3.0.3",
     "typescript": "^5.2.2",
-    "vite": "^4.4.11",
+    "vite": "^5.4.10",
     "vite-plugin-solid": "^2.7.1"
   },
   "dependencies": {

--- a/template-svelte-js/package.json
+++ b/template-svelte-js/package.json
@@ -23,7 +23,7 @@
     "zip": "npm run build && node src/zip.js"
   },
   "devDependencies": {
-    "@crxjs/vite-plugin": "^2.0.0-beta.19",
+    "@crxjs/vite-plugin": "^2.0.0-beta.26",
     "@sveltejs/vite-plugin-svelte": "2.4.6",
     "gulp": "^5.0.0",
     "gulp-zip": "^6.0.0",
@@ -31,6 +31,6 @@
     "prettier-plugin-svelte": "^3.0.3",
     "svelte": "^4.2.1",
     "svelte-preprocess": "^5.0.4",
-    "vite": "^4.4.11"
+    "vite": "^5.4.10"
   }
 }

--- a/template-svelte-ts/package.json
+++ b/template-svelte-ts/package.json
@@ -23,7 +23,7 @@
     "zip": "npm run build && node src/zip.js"
   },
   "devDependencies": {
-    "@crxjs/vite-plugin": "^2.0.0-beta.19",
+    "@crxjs/vite-plugin": "^2.0.0-beta.26",
     "@sveltejs/vite-plugin-svelte": "2.4.6",
     "@types/chrome": "^0.0.246",
     "gulp": "^5.0.0",
@@ -34,6 +34,6 @@
     "svelte-preprocess": "^5.0.4",
     "tslib": "^2.6.2",
     "typescript": "^5.2.2",
-    "vite": "^4.4.11"
+    "vite": "^5.4.10"
   }
 }

--- a/template-vanilla-js/package.json
+++ b/template-vanilla-js/package.json
@@ -23,10 +23,10 @@
     "zip": "npm run build && node src/zip.js"
   },
   "devDependencies": {
-    "@crxjs/vite-plugin": "^2.0.0-beta.19",
+    "@crxjs/vite-plugin": "^2.0.0-beta.26",
     "gulp": "^5.0.0",
     "gulp-zip": "^6.0.0",
     "prettier": "^3.0.3",
-    "vite": "^4.4.11"
+    "vite": "^5.4.10"
   }
 }

--- a/template-vanilla-ts/package.json
+++ b/template-vanilla-ts/package.json
@@ -23,12 +23,12 @@
     "zip": "npm run build && node src/zip.js"
   },
   "devDependencies": {
-    "@crxjs/vite-plugin": "^2.0.0-beta.19",
+    "@crxjs/vite-plugin": "^2.0.0-beta.26",
     "@types/chrome": "^0.0.246",
     "gulp": "^5.0.0",
     "gulp-zip": "^6.0.0",
     "prettier": "^3.0.3",
     "typescript": "^5.2.2",
-    "vite": "^4.4.11"
+    "vite": "^5.4.10"
   }
 }

--- a/template-vue-js/package.json
+++ b/template-vue-js/package.json
@@ -26,11 +26,11 @@
     "vue": "^3.2.37"
   },
   "devDependencies": {
-    "@crxjs/vite-plugin": "^2.0.0-beta.19",
+    "@crxjs/vite-plugin": "^2.0.0-beta.26",
     "@vitejs/plugin-vue": "^4.4.0",
     "gulp": "^5.0.0",
     "gulp-zip": "^6.0.0",
     "prettier": "^3.0.3",
-    "vite": "^4.4.11"
+    "vite": "^5.4.10"
   }
 }

--- a/template-vue-ts/package.json
+++ b/template-vue-ts/package.json
@@ -26,14 +26,14 @@
     "vue": "^3.3.4"
   },
   "devDependencies": {
-    "@crxjs/vite-plugin": "^2.0.0-beta.19",
+    "@crxjs/vite-plugin": "^2.0.0-beta.26",
     "@types/chrome": "^0.0.246",
     "@vitejs/plugin-vue": "^4.4.0",
     "gulp": "^5.0.0",
     "gulp-zip": "^6.0.0",
     "prettier": "^3.0.3",
     "typescript": "^5.2.2",
-    "vite": "^4.4.11",
+    "vite": "^5.4.10",
     "vue-tsc": "^1.8.18"
   }
 }


### PR DESCRIPTION
This CSP issue occurs on the latest Chrome version 130. Updating `@crxjs/vite-plugin` to version `2.0.0-beta.26` fixes the issue. 
Additionally, the Vite version has also been updated.